### PR TITLE
[FEAT]: Add weighted average cost of capital calculation

### DIFF
--- a/src/stocklyzer/services/__init__.py
+++ b/src/stocklyzer/services/__init__.py
@@ -4,5 +4,7 @@ from .interfaces import StockService
 from .stock_service import YFinanceStockService
 from .mock_service import MockStockService
 from .factory import ServiceFactory
+from .valuations import DiscountedCashFlow
 
-__all__ = ['StockService', 'YFinanceStockService', 'MockStockService', 'ServiceFactory']
+__all__ = ['StockService', 'YFinanceStockService', 'MockStockService', 'ServiceFactory', 
+           'DiscountedCashFlow']

--- a/src/stocklyzer/services/valuations/__init__.py
+++ b/src/stocklyzer/services/valuations/__init__.py
@@ -1,0 +1,5 @@
+"""Valuation services package."""
+
+from .dcf import DiscountedCashFlow
+
+__all__ = ['DiscountedCashFlow']

--- a/src/stocklyzer/services/valuations/dcf.py
+++ b/src/stocklyzer/services/valuations/dcf.py
@@ -11,85 +11,106 @@ logger = logging.getLogger(__name__)
 
 class DiscountedCashFlow:
     """Discounted Cash Flow valuation model."""
-    
+
     def __init__(self, ticker, perpetual_growth_rate=0.025, required_return=0.1):
         """Initialize DCF model."""
         self.ticker = ticker
         self.perpetual_growth_rate = Decimal(str(perpetual_growth_rate))
         self.required_return = Decimal(str(required_return))
-    
+
     def calculate_weighted_average_cost_of_capital(self) -> Optional[Decimal]:
         """Calculate WACC."""
         try:
-            # Get data
             info = self.ticker.info
-            
-            # Basic components
-            market_cap = Decimal(str(info['marketCap']))
-            beta = Decimal(str(info.get('beta', 1.0)))
-            
-            # Treasury rate
-            treasury_10y = Decimal(str(yf.Ticker("^TNX").history(period="1d").iloc[-1]['Close'] / 100))
-            
-            # Cost of Equity = Treasury + Beta * (Required Return - Treasury)
-            cost_of_equity = treasury_10y + beta * (self.required_return - treasury_10y)
-            cost_of_equity = Decimal(str(cost_of_equity))
-            
-            # Cost of Debt - try to calculate from Interest Expense, fallback to previous years
-            cost_debt_result = self._get_cost_of_debt_and_total_debt()
-            cost_of_debt, total_debt = cost_debt_result
+            latest_balance_sheet = self.ticker.balance_sheet.iloc[:, 0]
 
-            # wacc
+            market_cap = Decimal(str(info["marketCap"]))
+            total_debt = self._get_total_debt(latest_balance_sheet)
             total_value = total_debt + market_cap
-            wacc = cost_of_debt * (total_debt / total_value) + cost_of_equity * (market_cap / total_value)
-            logger.info(f"Ticker: {getattr(self.ticker, 'ticker', 'unknown')} | WACC: {wacc:.6f}")
+
+            cost_of_debt = self._get_cost_of_debt()
+            cost_of_equity = self._get_cost_of_equity()
+
+            cost_of_debt_percent = (total_debt / total_value) * cost_of_debt
+            cost_of_equity_percent = (market_cap / total_value) * cost_of_equity
+            wacc = cost_of_debt_percent + cost_of_equity_percent
+
+            logger.info(
+                f"Ticker: {getattr(self.ticker, 'ticker', 'unknown')} | WACC: {wacc:.6f}"
+            )
+
             return wacc
-            
+
         except Exception as e:
-            logger.error(f"WACC calculation failed for {getattr(self.ticker, 'ticker', 'unknown')}: {str(e)}")
+            logger.error(
+                f"WACC calculation failed for {getattr(self.ticker, 'ticker', 'unknown')}: {str(e)}"
+            )
             return None
-    
-    def _get_cost_of_debt_and_total_debt(self) -> Optional[Tuple[Decimal, Decimal]]:
-        """Get cost of debt and total debt from the same year, trying current year first, then previous years."""
-        
-        # Try each year's data
+
+    def _get_total_debt(self, balance_sheet) -> Optional[Decimal]:
+        long_term_debt = balance_sheet.get("Long Term Debt")
+        current_debt = balance_sheet.get("Current Debt")
+
+        if pd.notna(long_term_debt) and pd.notna(current_debt):
+            return Decimal(str(long_term_debt + current_debt))
+        else:
+            return Decimal(str(balance_sheet.get("Total Debt")))
+
+    def _get_cost_of_debt(self) -> Optional[Decimal]:
+        """Get cost of debt for current year first, then previous years if current does has no data."""
+        FIN_INTEREST_EXP = "Interest Expense"
+        CF_INTEREST_EXP = "Interest Paid Supplemental Data"
+
         for col in self.ticker.financials.columns:
-            financial_sheet_year = self.ticker.financials[col]
-            balance_sheet_year = self.ticker.balance_sheet[col]
-            
-            # Look for Interest Expense first
-            if 'Interest Expense' not in financial_sheet_year.index or pd.isna(financial_sheet_year['Interest Expense']):
-                continue  # Skip this year if no Interest Expense
-                
-            interest_expense = abs(float(financial_sheet_year['Interest Expense']))
-            # Get debt data from the same year only (no fallback for individual components)
-            long_term_debt = balance_sheet_year.get('Long Term Debt')
-            current_debt = balance_sheet_year.get('Current Debt')
+            current_financial_sheet = self.ticker.financials[col]
+            current_balance_sheet = self.ticker.balance_sheet[col]
+            current_cash_flow = self.ticker.cash_flow[col]
 
-            # Convert to float, handling NaN values - skip only if BOTH are missing
-            if pd.isna(long_term_debt) and pd.isna(current_debt):
-                continue  # Skip if no debt data available for this year
-            
-            if pd.isna(current_debt):
-                total_debt_year =  Decimal(balance_sheet_year.get('Total Debt'))
+            if FIN_INTEREST_EXP in current_financial_sheet.index and pd.notna(
+                current_financial_sheet[FIN_INTEREST_EXP]
+            ):
+                interest_expense = current_financial_sheet[FIN_INTEREST_EXP]
+            elif CF_INTEREST_EXP in current_cash_flow.index and pd.notna(
+                current_cash_flow[CF_INTEREST_EXP]
+            ):
+                interest_expense = current_cash_flow[CF_INTEREST_EXP]
             else:
-                long_term_debt = float(long_term_debt)
-                current_debt = float(current_debt)
-                total_debt_year = Decimal(str(long_term_debt + current_debt))
-            
-            # Calculate cost of debt: Interest Expense / Total Debt (same year)
-            cost_of_debt = Decimal(str(interest_expense)) / Decimal(str(total_debt_year))
+                continue
 
-            logger.info(f"Using cost of debt from {col}: {cost_of_debt:.4f}, total debt: ${total_debt_year}")
-            return (cost_of_debt, total_debt_year)
-        
-        # No data available
-        logger.warning("Could not calculate cost of debt from financial data")
+            cost_of_debt_pretax = Decimal(str(interest_expense)) / self._get_total_debt(
+                current_balance_sheet
+            )
+            cost_of_debt = cost_of_debt_pretax * (
+                1 - self._get_tax_rate(current_financial_sheet)
+            )
+
+            logger.info(f"Cost of debt: {cost_of_debt:.4f}, year: {col}")
+
+            return Decimal(cost_of_debt)
+
         return None
+
+    def _get_cost_of_equity(self) -> Optional[Decimal]:
+        beta = Decimal(str(self.ticker.info.get("beta", 1.0)))
+
+        # Treasury rate
+        tnx = yf.Ticker("^TNX")
+        treasury_10y = Decimal(str(tnx.history(period="1d").iloc[-1]["Close"] / 100))
+
+        # Cost of Equity = Treasury + Beta * (Required Return - Treasury)
+        cost_of_equity = treasury_10y + beta * (self.required_return - treasury_10y)
+
+        return Decimal(str(cost_of_equity))
+
+    def _get_tax_rate(self, financial) -> Optional[Decimal]:
+        """Get tax rate"""
+        pretax_income = financial.loc["Pretax Income"]
+        income_tax_expense = financial.loc["Tax Provision"]
+        return Decimal(str(income_tax_expense)) / Decimal(str(pretax_income))
 
 
 if __name__ == "__main__":
-    ticker = yf.Ticker("PYPL")
+    ticker = yf.Ticker("lulu")
     dcf = DiscountedCashFlow(ticker)
     wacc = dcf.calculate_weighted_average_cost_of_capital()
     print(f"WACC: {wacc}")

--- a/src/stocklyzer/services/valuations/dcf.py
+++ b/src/stocklyzer/services/valuations/dcf.py
@@ -1,0 +1,95 @@
+"""Discounted Cash Flow (DCF) valuation models and calculations."""
+
+from decimal import Decimal
+from typing import Optional, Tuple
+import yfinance as yf
+import pandas as pd
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class DiscountedCashFlow:
+    """Discounted Cash Flow valuation model."""
+    
+    def __init__(self, ticker, perpetual_growth_rate=0.025, required_return=0.1):
+        """Initialize DCF model."""
+        self.ticker = ticker
+        self.perpetual_growth_rate = Decimal(str(perpetual_growth_rate))
+        self.required_return = Decimal(str(required_return))
+    
+    def calculate_weighted_average_cost_of_capital(self) -> Optional[Decimal]:
+        """Calculate WACC."""
+        try:
+            # Get data
+            info = self.ticker.info
+            
+            # Basic components
+            market_cap = Decimal(str(info['marketCap']))
+            beta = Decimal(str(info.get('beta', 1.0)))
+            
+            # Treasury rate
+            treasury_10y = Decimal(str(yf.Ticker("^TNX").history(period="1d").iloc[-1]['Close'] / 100))
+            
+            # Cost of Equity = Treasury + Beta * (Required Return - Treasury)
+            cost_of_equity = treasury_10y + beta * (self.required_return - treasury_10y)
+            cost_of_equity = Decimal(str(cost_of_equity))
+            
+            # Cost of Debt - try to calculate from Interest Expense, fallback to previous years
+            cost_debt_result = self._get_cost_of_debt_and_total_debt()
+            cost_of_debt, total_debt = cost_debt_result
+
+            # wacc
+            total_value = total_debt + market_cap
+            wacc = cost_of_debt * (total_debt / total_value) + cost_of_equity * (market_cap / total_value)
+            logger.info(f"Ticker: {getattr(self.ticker, 'ticker', 'unknown')} | WACC: {wacc:.6f}")
+            return wacc
+            
+        except Exception as e:
+            logger.error(f"WACC calculation failed for {getattr(self.ticker, 'ticker', 'unknown')}: {str(e)}")
+            return None
+    
+    def _get_cost_of_debt_and_total_debt(self) -> Optional[Tuple[Decimal, Decimal]]:
+        """Get cost of debt and total debt from the same year, trying current year first, then previous years."""
+        
+        # Try each year's data
+        for col in self.ticker.financials.columns:
+            financial_sheet_year = self.ticker.financials[col]
+            balance_sheet_year = self.ticker.balance_sheet[col]
+            
+            # Look for Interest Expense first
+            if 'Interest Expense' not in financial_sheet_year.index or pd.isna(financial_sheet_year['Interest Expense']):
+                continue  # Skip this year if no Interest Expense
+                
+            interest_expense = abs(float(financial_sheet_year['Interest Expense']))
+            # Get debt data from the same year only (no fallback for individual components)
+            long_term_debt = balance_sheet_year.get('Long Term Debt')
+            current_debt = balance_sheet_year.get('Current Debt')
+
+            # Convert to float, handling NaN values - skip only if BOTH are missing
+            if pd.isna(long_term_debt) and pd.isna(current_debt):
+                continue  # Skip if no debt data available for this year
+            
+            if pd.isna(current_debt):
+                total_debt_year =  Decimal(balance_sheet_year.get('Total Debt'))
+            else:
+                long_term_debt = float(long_term_debt)
+                current_debt = float(current_debt)
+                total_debt_year = Decimal(str(long_term_debt + current_debt))
+            
+            # Calculate cost of debt: Interest Expense / Total Debt (same year)
+            cost_of_debt = Decimal(str(interest_expense)) / Decimal(str(total_debt_year))
+
+            logger.info(f"Using cost of debt from {col}: {cost_of_debt:.4f}, total debt: ${total_debt_year}")
+            return (cost_of_debt, total_debt_year)
+        
+        # No data available
+        logger.warning("Could not calculate cost of debt from financial data")
+        return None
+
+
+if __name__ == "__main__":
+    ticker = yf.Ticker("PYPL")
+    dcf = DiscountedCashFlow(ticker)
+    wacc = dcf.calculate_weighted_average_cost_of_capital()
+    print(f"WACC: {wacc}")

--- a/tests/test_dcf.py
+++ b/tests/test_dcf.py
@@ -1,0 +1,319 @@
+"""Unit tests for DiscountedCashFlow class."""
+
+import unittest
+from unittest.mock import Mock, patch
+from decimal import Decimal
+import pandas as pd
+import sys
+from pathlib import Path
+
+# Add the src directory to the Python path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from stocklyzer.services.valuations import DiscountedCashFlow
+
+
+class TestDiscountedCashFlow(unittest.TestCase):
+    """Test cases for DiscountedCashFlow class."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create mock ticker
+        self.mock_ticker = Mock()
+        self.dcf = DiscountedCashFlow(
+            ticker=self.mock_ticker,
+            perpetual_growth_rate=0.025,
+            required_return=0.1
+        )
+    
+    def test_dcf_initialization(self):
+        """Test DCF initialization with default parameters."""
+        dcf = DiscountedCashFlow(self.mock_ticker)
+        
+        self.assertEqual(dcf.perpetual_growth_rate, Decimal('0.025'))
+        self.assertEqual(dcf.required_return, Decimal('0.1'))
+        self.assertEqual(dcf.ticker, self.mock_ticker)
+    
+    def test_dcf_initialization_custom_params(self):
+        """Test DCF initialization with custom parameters."""
+        dcf = DiscountedCashFlow(
+            ticker=self.mock_ticker,
+            perpetual_growth_rate=0.03,
+            required_return=0.09
+        )
+        
+        self.assertEqual(dcf.perpetual_growth_rate, Decimal('0.03'))
+        self.assertEqual(dcf.required_return, Decimal('0.09'))
+    
+    @patch('stocklyzer.services.valuations.dcf.yf.Ticker')
+    def test_wacc_calculation_success(self, mock_yf_ticker):
+        """Test successful WACC calculation."""
+        # Setup mock data
+        self.mock_ticker.info = {
+            'marketCap': 3400000000000,  # $3.4T
+            'beta': 1.2
+        }
+        
+        # Mock balance sheet
+        balance_data = pd.Series({
+            'Long Term Debt': 85000000000.0,  # $85B
+            'Current Debt': 21000000000.0     # $21B
+        })
+        self.mock_ticker.balance_sheet = pd.DataFrame([balance_data]).T
+        
+        # Mock financials with Interest Expense data
+        financials_data = pd.Series({
+            'Revenue': 100000000000.0,
+            'Interest Expense': 2000000000.0  # $2B interest expense
+        })
+        self.mock_ticker.financials = pd.DataFrame([financials_data]).T
+        
+        # Mock Treasury rate
+        treasury_hist = pd.DataFrame({'Close': [4.5]})  # 4.5%
+        mock_treasury_ticker = Mock()
+        mock_treasury_ticker.history.return_value = treasury_hist
+        mock_yf_ticker.return_value = mock_treasury_ticker
+        
+        # Calculate WACC
+        wacc = self.dcf.calculate_weighted_average_cost_of_capital()
+        
+        # Verify WACC is calculated
+        self.assertIsNotNone(wacc)
+        self.assertIsInstance(wacc, Decimal)
+        self.assertGreater(wacc, 0)
+        
+        # Verify Treasury ticker was called
+        mock_yf_ticker.assert_called_with("^TNX")
+        mock_treasury_ticker.history.assert_called_with(period="1d")
+    
+    def test_wacc_calculation_missing_market_cap(self):
+        """Test WACC calculation with missing market cap."""
+        # Setup mock data without market cap
+        self.mock_ticker.info = {}
+        
+        balance_data = pd.Series({
+            'Long Term Debt': 85000000000.0,
+            'Current Debt': 21000000000.0
+        })
+        self.mock_ticker.balance_sheet = pd.DataFrame([balance_data]).T
+        
+        financials_data = pd.Series({'Revenue': 100000000000.0})
+        self.mock_ticker.financials = pd.DataFrame([financials_data]).T
+        
+        # Calculate WACC
+        wacc = self.dcf.calculate_weighted_average_cost_of_capital()
+        
+        # Should return None due to missing market cap
+        self.assertIsNone(wacc)
+    
+    def test_wacc_calculation_missing_debt_data(self):
+        """Test WACC calculation with missing debt data."""
+        # Setup mock data without debt
+        self.mock_ticker.info = {
+            'marketCap': 3400000000000,
+            'beta': 1.2
+        }
+        
+        # Empty balance sheet
+        self.mock_ticker.balance_sheet = pd.DataFrame()
+        self.mock_ticker.financials = pd.DataFrame()
+        
+        # Calculate WACC
+        wacc = self.dcf.calculate_weighted_average_cost_of_capital()
+        
+        # Should return None due to missing debt data
+        self.assertIsNone(wacc)
+    
+    @patch('stocklyzer.services.valuations.dcf.yf.Ticker')
+    def test_wacc_calculation_treasury_fetch_failure(self, mock_yf_ticker):
+        """Test WACC calculation when Treasury rate fetch fails."""
+        # Setup mock data
+        self.mock_ticker.info = {
+            'marketCap': 3400000000000,
+            'beta': 1.2
+        }
+        
+        balance_data = pd.Series({
+            'Long Term Debt': 85000000000.0,
+            'Current Debt': 21000000000.0
+        })
+        self.mock_ticker.balance_sheet = pd.DataFrame([balance_data]).T
+        
+        financials_data = pd.Series({'Revenue': 100000000000.0})
+        self.mock_ticker.financials = pd.DataFrame([financials_data]).T
+        
+        # Mock Treasury rate fetch failure
+        mock_yf_ticker.side_effect = Exception("Network error")
+        
+        # Calculate WACC
+        wacc = self.dcf.calculate_weighted_average_cost_of_capital()
+        
+        # Should return None due to Treasury fetch failure
+        self.assertIsNone(wacc)
+    
+    @patch('stocklyzer.services.valuations.dcf.logger')
+    def test_wacc_calculation_logs_error(self, mock_logger):
+        """Test that WACC calculation logs errors properly."""
+        # Setup mock to cause an exception
+        self.mock_ticker.info = None  # This will cause an error
+        
+        # Calculate WACC
+        wacc = self.dcf.calculate_weighted_average_cost_of_capital()
+        
+        # Should return None and log error
+        self.assertIsNone(wacc)
+        mock_logger.error.assert_called_once()
+        
+        # Check that error message contains ticker info
+        error_call = mock_logger.error.call_args[0][0]
+        self.assertIn("WACC calculation failed", error_call)
+    
+    def test_wacc_calculation_real_aapl_data(self):
+        """Test WACC calculation with real AAPL data."""
+        try:
+            import yfinance as yf
+            
+            # Create DCF with real AAPL ticker
+            real_ticker = yf.Ticker('AAPL')
+            dcf = DiscountedCashFlow(real_ticker, perpetual_growth_rate=0.025, required_return=0.1)
+            
+            # Calculate WACC
+            wacc = dcf.calculate_weighted_average_cost_of_capital()
+            
+            # Assert that WACC is calculated and is a valid value
+            self.assertIsNotNone(wacc, "WACC should not be None for AAPL")
+            self.assertIsInstance(wacc, Decimal, "WACC should be a Decimal")
+            self.assertGreater(wacc, 0, "WACC should be positive")
+            self.assertLess(wacc, 1, "WACC should be less than 100%")
+            
+        except ImportError:
+            self.skipTest("yfinance not available")
+        except Exception as e:
+            self.fail(f"Real AAPL test failed with error: {e}")
+    
+    def test_wacc_calculation_real_data_multiple_stocks(self):
+        """Test WACC calculation with real data for AAPL, GOOG, and MSFT."""
+        try:
+            import yfinance as yf
+            
+            tickers = ['AAPL', 'GOOG', 'MSFT']
+            results = {}
+            
+            for symbol in tickers:
+                try:
+                    # Create DCF with real ticker
+                    real_ticker = yf.Ticker(symbol)
+                    dcf = DiscountedCashFlow(real_ticker, perpetual_growth_rate=0.025, required_return=0.1)
+                    
+                    # Calculate WACC
+                    wacc = dcf.calculate_weighted_average_cost_of_capital()
+                    results[symbol] = wacc
+                    
+                    if wacc is not None:
+                        # Assert that WACC is calculated and is a valid value
+                        self.assertIsInstance(wacc, Decimal, f"WACC should be a Decimal for {symbol}")
+                        self.assertGreater(wacc, 0, f"WACC should be positive for {symbol}")
+                        self.assertLess(wacc, 1, f"WACC should be less than 100% for {symbol}")
+                        
+                        # Print the actual WACC for manual verification
+                        print(f"\n{symbol} WACC: {wacc:.6f} ({wacc * 100:.2f}%)")
+                    else:
+                        print(f"\n{symbol} WACC: Could not calculate (missing data)")
+                        
+                except Exception as e:
+                    print(f"\n{symbol} WACC: Error - {str(e)}")
+                    results[symbol] = None
+            
+            # At least one should have calculated successfully
+            successful_calculations = [v for v in results.values() if v is not None]
+            self.assertGreater(len(successful_calculations), 0, 
+                             "At least one WACC calculation should succeed")
+            
+        except ImportError:
+            self.skipTest("yfinance not available for real data test")
+    
+    def test_get_cost_of_debt_and_total_debt_returns_both_values(self):
+        """Test that _get_cost_of_debt_and_total_debt returns both cost of debt and total debt."""
+        # Mock ticker with valid data
+        mock_financials = pd.DataFrame({
+            '2024-12-31': pd.Series({
+                'Interest Expense': 600000000,  # $600M interest expense
+                'Revenue': 120000000000
+            })
+        })
+        
+        mock_balance_sheet = pd.DataFrame({
+            '2024-12-31': pd.Series({
+                'Long Term Debt': 20000000000,  # $20B long term debt
+                'Current Debt': 5000000000      # $5B current debt
+            })
+        })
+        
+        self.mock_ticker.financials = mock_financials
+        self.mock_ticker.balance_sheet = mock_balance_sheet
+        
+        result = self.dcf._get_cost_of_debt_and_total_debt()
+        
+        self.assertIsNotNone(result)
+        cost_of_debt, total_debt = result
+        
+        # Expected: 600M / (20B + 5B) = 600M / 25B = 2.4%
+        expected_cost = Decimal('600000000') / Decimal('25000000000')
+        expected_total_debt = Decimal('25000000000')
+        
+        self.assertEqual(cost_of_debt, expected_cost)
+        self.assertEqual(total_debt, expected_total_debt)
+    
+    def test_wacc_calculation_uses_same_year_debt_as_interest_expense(self):
+        """Test that WACC calculation uses debt from the same year as Interest Expense."""
+        # Mock ticker where different years have different debt levels
+        mock_financials = pd.DataFrame({
+            '2024-12-31': pd.Series({
+                # 2024 has no Interest Expense
+                'Revenue': 100000000000
+            }),
+            '2023-12-31': pd.Series({
+                # 2023 has Interest Expense - should use 2023 debt
+                'Interest Expense': 800000000,  # $800M interest expense
+                'Revenue': 95000000000
+            })
+        })
+        
+        mock_balance_sheet = pd.DataFrame({
+            '2024-12-31': pd.Series({
+                'Long Term Debt': 30000000000,  # $30B - should NOT be used
+                'Current Debt': 10000000000     # $10B - should NOT be used
+            }),
+            '2023-12-31': pd.Series({
+                'Long Term Debt': 15000000000,  # $15B - should be used
+                'Current Debt': 5000000000      # $5B - should be used
+            })
+        })
+        
+        # Mock other required data for WACC
+        self.mock_ticker.info = {
+            'marketCap': 2000000000000,  # $2T
+            'beta': 1.1
+        }
+        self.mock_ticker.financials = mock_financials
+        self.mock_ticker.balance_sheet = mock_balance_sheet
+        
+        # Mock Treasury rate
+        with patch('stocklyzer.services.valuations.dcf.yf.Ticker') as mock_yf_ticker:
+            treasury_hist = pd.DataFrame({'Close': [4.2]})  # 4.2%
+            mock_treasury_ticker = Mock()
+            mock_treasury_ticker.history.return_value = treasury_hist
+            mock_yf_ticker.return_value = mock_treasury_ticker
+            
+            # Calculate WACC
+            wacc = self.dcf.calculate_weighted_average_cost_of_capital()
+            
+            # Should succeed using 2023 data (Interest Expense and debt from same year)
+            self.assertIsNotNone(wacc)
+            self.assertIsInstance(wacc, Decimal)
+            self.assertGreater(wacc, 0)
+            self.assertLess(wacc, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Weighted average cost of capital is required to calculate discounted cash flow model. This PR implements WACC.
```
class DiscountedCashFlow(yf.Ticker, perpetual_growth_rate=0.025, required_return=0.1):
      def calculate_weighted_average_cost_of_capital(self) -> Optional[Decimal]:
```

### Formula:
```
Total Debt  = Long term debt + Current debt (Short term debt)
Cost of Equity = 10-year U.S. Treasury rate (^TNX) + Beta * (required_return - 10-year U.S. Treasury rate)
Cost of Debt =  (Interest expense / Total Debt ) * (1 -Tax Provision/Pretax Income)
Weighted Average Cost of Capital = Cost of Debt * (Total Debt / (Total Debt + Total Market Cap)) + Cost of Equity  * Total Market Cap / (Total Debt +Total Market Cap)) 
```
### Notes
* Cannot use default values **except** for the ones provided in `__init__`.
* When `Current Debt` is not available, use `Total Debt` from yfinance.
* If `Interest Expense` not available in `financials`, use `Interest Paid Supplemental Data` cash flow to calculate cost of debt. If neither of `Interest Expense` nor `Interest Paid Supplemental Data` available for current year, use previous year.
